### PR TITLE
feature/script-config

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -22,7 +22,7 @@ class ScriptConfig:
             Example: {"file_clinical.tsv": "https://example.com/file_clinical.tsv"}
     """
 
-    project_root = '..'
+    project_root = '.'
     data_dir = 'data'
     raw_data_dir = 'raw'
     processed_dir = 'processed'

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -117,3 +117,19 @@ class ProductionConfig(ScriptConfig):
             "PDX_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
             "PDX_ribo_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-Ribodeplete_for_GEO_20240520.tsv"
         }
+
+class CLPolyA(ScriptConfig):
+    """
+    Configuration for only cell_line_polyA data. This is useful for testing and development for a single compendium and
+    no compendium merging.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.expression_targets = {
+            "cell_line_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/CellLinePolyA_21.06_hugo_log2tpm_58581genes_2021-06-15.tsv",
+        }
+
+        self.clinical_targets = {
+            "cell_line_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_CellLinePolyA_21.06_for_GEO_20240520.tsv",
+       }

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -74,7 +74,7 @@ class ScriptConfig:
         Returns:
             dict: A dictionary where keys are expression file paths and values are URLs.
         """
-        return {os.path.join(cls.raw_data_dir, file): url for file, url in cls.expression_targets.items()}
+        return {os.path.join(cls.raw_data_dir_path(), file): url for file, url in cls.expression_targets.items()}
 
     @classmethod
     def get_path_clinical_url_targets(cls):
@@ -84,7 +84,7 @@ class ScriptConfig:
         Returns:
             dict: A dictionary where keys are clinical file paths and values are URLs.
         """
-        return {os.path.join(cls.raw_data_dir, file): url for file, url in cls.clinical_targets.items()}
+        return {os.path.join(cls.raw_data_dir_path(), file): url for file, url in cls.clinical_targets.items()}
 
     @classmethod
     def get_expression_file_paths(cls):
@@ -124,7 +124,7 @@ class ProductionConfig(ScriptConfig):
         "PDX_ribo_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-Ribodeplete_for_GEO_20240520.tsv"
     }
 
-class PDX_PolyA(ScriptConfig):
+class PDXPolyA(ScriptConfig):
     """
     Configuration for only PDX\_polyA data. This is useful for testing and development for a single compendium and
     no compendium merging.
@@ -159,7 +159,7 @@ def get_config(config_name):
     if config_name == "production":
         return ProductionConfig
     elif config_name == "pdx_polya":
-        return PDX_PolyA
+        return PDXPolyA
     else:
         print(f"Invalid configuration name: {config_name}. Valid configurations are: {', '.join(VALID_CONFIGS)}")
         return None

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -130,7 +130,7 @@ class PDXPolyA(ScriptConfig):
     no compendium merging.
     """
 
-    data_dir = 'data/pdx_polya'
+    data_dir = os.path.join('data', 'pdx_polya')
     expression_targets = {
         "PDX_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
     }

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -1,0 +1,99 @@
+import os
+
+class ScriptConfig:
+    """
+    Base configuration class. Do not use attributes to access file or directory paths directly. Instead, use methods
+    provided. The attributes are meant to be overridden by subclasses for changes in file names or directory structure.
+    The included methods build the full paths to files and directories based on the attributes which are safe to use
+    in scripts.
+
+    Attributes:
+        project_root (str): The name of the project root directory.
+        data_dir (str): The name of the data directory.
+        raw_data_dir (str): The name of the raw data directory.
+        processed_dir (str): The name of the processed data directory.
+        expression_file (str): The name of the expression data file.
+        clinical_file (str): The name of the clinical data file.
+        expression_targets (dict): A dictionary for file targets of expression data. Keys should be the file name with
+            proper extension and values should be the URL to download the file.
+            Example: {"file_expression.tsv": "https://example.com/file_expression.tsv"}
+        clinical_targets (dict): A dictionary for file targets of expression data. Keys should be the file name with
+            proper extension and values should be the URL to download the file.
+            Example: {"file_clinical.tsv": "https://example.com/file_clinical.tsv"}
+    """
+
+    def __init__(self):
+        self.project_root = '..'
+        self.data_dir = 'data'
+        self.raw_data_dir = 'raw'
+        self.processed_dir = 'processed'
+        self.expression_file = 'processed_compendium.tsv'
+        self.clinical_file = 'processed_clinical_data.tsv'
+        self.expression_targets = {}
+        self.clinical_targets = {}
+
+    def data_dir_path(self):
+        """
+        Get the full path to the data directory.
+        """
+        return os.path.join(self.project_root, self.data_dir)
+
+    def raw_data_dir_path(self):
+        """
+        Get the path to the raw data directory relative to the project root directory.
+        """
+        return os.path.join(self.data_dir_path(), self.raw_data_dir)
+
+    def processed_dir_path(self):
+        """
+        Get the path to the processed data directory relative to the project root directory.
+        """
+        return os.path.join(self.data_dir_path(), self.processed_dir)
+
+    def expression_file_path(self):
+        """
+        Get the path to the expression data file relative to the project root directory.
+        """
+        return os.path.join(self.processed_dir_path(), self.expression_file)
+
+    def clinical_file_path(self):
+        """
+        Get the path to the expression data file relative to the project root directory.
+        """
+        return os.path.join(self.processed_dir_path(), self.clinical_file)
+
+    def get_path_expression_url_targets(self):
+        """
+        Get a dictionary of file paths to URLs for downloading expression files.
+
+        Returns:
+            dict: A dictionary where keys are expression file paths and values are URLs.
+        """
+        return {os.path.join(self.raw_data_dir, file): url for file, url in self.expression_targets.items()}
+
+    def get_path_clinical_url_targets(self):
+        """
+        Get a dictionary of file paths to URLs for downloading clinical files.
+
+        Returns:
+            dict: A dictionary where keys are clinical file paths and values are URLs.
+        """
+        return {os.path.join(self.raw_data_dir, file): url for file, url in self.clinical_targets.items()}
+
+    def get_expression_file_paths(self):
+        """
+        Get a list of expression file paths.
+
+        Returns:
+            list: A list of expression file paths.
+        """
+        return [os.path.join(self.raw_data_dir, file) for file in self.expression_targets]
+
+    def get_clinical_file_paths(self):
+        """
+        Get a list of clinical file paths.
+
+        Returns:
+            list: A list of clinical file paths.
+        """
+        return [os.path.join(self.raw_data_dir, file) for file in self.clinical_targets]

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -124,22 +124,22 @@ class ProductionConfig(ScriptConfig):
         "PDX_ribo_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-Ribodeplete_for_GEO_20240520.tsv"
     }
 
-class CLPolyA(ScriptConfig):
+class PDX_PolyA(ScriptConfig):
     """
-    Configuration for only cell\_line\_polyA data. This is useful for testing and development for a single compendium and
+    Configuration for only PDX\_polyA data. This is useful for testing and development for a single compendium and
     no compendium merging.
     """
 
+    data_dir = 'data/pdx_polya'
     expression_targets = {
-        "cell_line_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/CellLinePolyA_21.06_hugo_log2tpm_58581genes_2021-06-15.tsv",
+        "PDX_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
     }
 
     clinical_targets = {
-        "cell_line_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_CellLinePolyA_21.06_for_GEO_20240520.tsv",
+        "PDX_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
     }
 
-# Define a constant list of valid configurations
-VALID_CONFIGS = ["production", "clpolya"]
+VALID_CONFIGS = ["production", "pdx_polya"]
 
 def get_config(config_name):
     """
@@ -148,7 +148,7 @@ def get_config(config_name):
     Args:
         config_name (str): The name of the configuration to use. Available options are:
             - "production": Use the ProductionConfig class.
-            - "clpolya": Use the CLPolyA class.
+            - "pdx_polya": Use the PDX_PolyA class.
 
     Returns:
         ScriptConfig: The configuration class corresponding to the provided name, or None if an invalid configuration name is provided.
@@ -158,8 +158,8 @@ def get_config(config_name):
     """
     if config_name == "production":
         return ProductionConfig
-    elif config_name == "clpolya":
-        return CLPolyA
+    elif config_name == "pdx_polya":
+        return PDX_PolyA
     else:
         print(f"Invalid configuration name: {config_name}. Valid configurations are: {', '.join(VALID_CONFIGS)}")
         return None

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -22,114 +22,118 @@ class ScriptConfig:
             Example: {"file_clinical.tsv": "https://example.com/file_clinical.tsv"}
     """
 
-    def __init__(self):
-        self.project_root = '..'
-        self.data_dir = 'data'
-        self.raw_data_dir = 'raw'
-        self.processed_dir = 'processed'
-        self.expression_file = 'processed_compendium.tsv'
-        self.clinical_file = 'processed_clinical_data.tsv'
-        self.expression_targets = {}
-        self.clinical_targets = {}
+    project_root = '..'
+    data_dir = 'data'
+    raw_data_dir = 'raw'
+    processed_dir = 'processed'
+    expression_file = 'processed_compendium.tsv'
+    clinical_file = 'processed_clinical_data.tsv'
+    expression_targets = {}
+    clinical_targets = {}
 
-    def data_dir_path(self):
+    @classmethod
+    def data_dir_path(cls):
         """
         Get the full path to the data directory.
         """
-        return os.path.join(self.project_root, self.data_dir)
+        return os.path.join(cls.project_root, cls.data_dir)
 
-    def raw_data_dir_path(self):
+    @classmethod
+    def raw_data_dir_path(cls):
         """
         Get the path to the raw data directory relative to the project root directory.
         """
-        return os.path.join(self.data_dir_path(), self.raw_data_dir)
+        return os.path.join(cls.data_dir_path(), cls.raw_data_dir)
 
-    def processed_dir_path(self):
+    @classmethod
+    def processed_dir_path(cls):
         """
         Get the path to the processed data directory relative to the project root directory.
         """
-        return os.path.join(self.data_dir_path(), self.processed_dir)
+        return os.path.join(cls.data_dir_path(), cls.processed_dir)
 
-    def expression_file_path(self):
+    @classmethod
+    def expression_file_path(cls):
         """
         Get the path to the expression data file relative to the project root directory.
         """
-        return os.path.join(self.processed_dir_path(), self.expression_file)
+        return os.path.join(cls.processed_dir_path(), cls.expression_file)
 
-    def clinical_file_path(self):
+    @classmethod
+    def clinical_file_path(cls):
         """
         Get the path to the expression data file relative to the project root directory.
         """
-        return os.path.join(self.processed_dir_path(), self.clinical_file)
+        return os.path.join(cls.processed_dir_path(), cls.clinical_file)
 
-    def get_path_expression_url_targets(self):
+    @classmethod
+    def get_path_expression_url_targets(cls):
         """
         Get a dictionary of file paths to URLs for downloading expression files.
 
         Returns:
             dict: A dictionary where keys are expression file paths and values are URLs.
         """
-        return {os.path.join(self.raw_data_dir, file): url for file, url in self.expression_targets.items()}
+        return {os.path.join(cls.raw_data_dir, file): url for file, url in cls.expression_targets.items()}
 
-    def get_path_clinical_url_targets(self):
+    @classmethod
+    def get_path_clinical_url_targets(cls):
         """
         Get a dictionary of file paths to URLs for downloading clinical files.
 
         Returns:
             dict: A dictionary where keys are clinical file paths and values are URLs.
         """
-        return {os.path.join(self.raw_data_dir, file): url for file, url in self.clinical_targets.items()}
+        return {os.path.join(cls.raw_data_dir, file): url for file, url in cls.clinical_targets.items()}
 
-    def get_expression_file_paths(self):
+    @classmethod
+    def get_expression_file_paths(cls):
         """
         Get a list of expression file paths.
 
         Returns:
             list: A list of expression file paths.
         """
-        return [os.path.join(self.raw_data_dir, file) for file in self.expression_targets]
+        return [os.path.join(cls.raw_data_dir, file) for file in cls.expression_targets]
 
-    def get_clinical_file_paths(self):
+    @classmethod
+    def get_clinical_file_paths(cls):
         """
         Get a list of clinical file paths.
 
         Returns:
             list: A list of clinical file paths.
         """
-        return [os.path.join(self.raw_data_dir, file) for file in self.clinical_targets]
+        return [os.path.join(cls.raw_data_dir, file) for file in cls.clinical_targets]
 
 class ProductionConfig(ScriptConfig):
 
-    def __init__(self):
-        super().__init__()
-        self.expression_targets = {
-            "tumor_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/TumorCompendium_v11_PolyA_hugo_log2tpm_58581genes_2020-04-09.tsv",
-            "tumor_ribo_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/TreehousePEDv9_Ribodeplete_unique_hugo_log2_tpm_plus_1.2019-03-25.tsv",
-            "cell_line_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/CellLinePolyA_21.06_hugo_log2tpm_58581genes_2021-06-15.tsv",
-            "PDX_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
-            "PDX_ribo_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-Ribodeplete_for_GEO_20240520.tsv"
-        }
+    expression_targets = {
+        "tumor_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/TumorCompendium_v11_PolyA_hugo_log2tpm_58581genes_2020-04-09.tsv",
+        "tumor_ribo_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/TreehousePEDv9_Ribodeplete_unique_hugo_log2_tpm_plus_1.2019-03-25.tsv",
+        "cell_line_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/CellLinePolyA_21.06_hugo_log2tpm_58581genes_2021-06-15.tsv",
+        "PDX_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
+        "PDX_ribo_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-Ribodeplete_for_GEO_20240520.tsv"
+    }
 
-        self.clinical_targets = {
-            "tumor_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_TumorCompendium_v11_PolyA_for_GEO_20240520.tsv",
-            "tumor_ribo_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/Treehouse-PDX-Compendium-22.03-PolyA_hugo_log2tpm_58581genes_2022-03-09.tsv",
-            "cell_line_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_CellLinePolyA_21.06_for_GEO_20240520.tsv",
-            "PDX_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
-            "PDX_ribo_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-Ribodeplete_for_GEO_20240520.tsv"
-        }
+    clinical_targets = {
+        "tumor_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_TumorCompendium_v11_PolyA_for_GEO_20240520.tsv",
+        "tumor_ribo_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/Treehouse-PDX-Compendium-22.03-PolyA_hugo_log2tpm_58581genes_2022-03-09.tsv",
+        "cell_line_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_CellLinePolyA_21.06_for_GEO_20240520.tsv",
+        "PDX_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
+        "PDX_ribo_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-Ribodeplete_for_GEO_20240520.tsv"
+    }
 
 class CLPolyA(ScriptConfig):
     """
-    Configuration for only cell_line_polyA data. This is useful for testing and development for a single compendium and
+    Configuration for only cell\_line\_polyA data. This is useful for testing and development for a single compendium and
     no compendium merging.
     """
 
-    def __init__(self):
-        super().__init__()
-        self.expression_targets = {
-            "cell_line_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/CellLinePolyA_21.06_hugo_log2tpm_58581genes_2021-06-15.tsv",
-        }
+    expression_targets = {
+        "cell_line_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/CellLinePolyA_21.06_hugo_log2tpm_58581genes_2021-06-15.tsv",
+    }
 
-        self.clinical_targets = {
-            "cell_line_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_CellLinePolyA_21.06_for_GEO_20240520.tsv",
-       }
+    clinical_targets = {
+        "cell_line_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_CellLinePolyA_21.06_for_GEO_20240520.tsv",
+    }

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -2,10 +2,14 @@ import os
 
 class ScriptConfig:
     """
-    Base configuration class. Do not use attributes to access file or directory paths directly. Instead, use methods
-    provided. The attributes are meant to be overridden by subclasses for changes in file names or directory structure.
-    The included methods build the full paths to files and directories based on the attributes which are safe to use
-    in scripts.
+    Script Configurations define what data a script should use to run and the paths to the data within the project
+    structure. Script can use these configurations to download data, process data, and output data. This class is meant
+    to be subclassed for specific configurations.
+
+    Do not use attributes to access file or directory paths directly. Instead, use class methods provided. The
+    attributes are meant to be overridden by subclasses for changes in file names or directory structure.
+    The included class methods build the full paths to files and directories based on the attributes which is what
+    script can safely use.
 
     Attributes:
         project_root (str): The name of the project root directory.

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -97,3 +97,23 @@ class ScriptConfig:
             list: A list of clinical file paths.
         """
         return [os.path.join(self.raw_data_dir, file) for file in self.clinical_targets]
+
+class ProductionConfig(ScriptConfig):
+
+    def __init__(self):
+        super().__init__()
+        self.expression_targets = {
+            "tumor_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/TumorCompendium_v11_PolyA_hugo_log2tpm_58581genes_2020-04-09.tsv",
+            "tumor_ribo_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/TreehousePEDv9_Ribodeplete_unique_hugo_log2_tpm_plus_1.2019-03-25.tsv",
+            "cell_line_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/CellLinePolyA_21.06_hugo_log2tpm_58581genes_2021-06-15.tsv",
+            "PDX_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
+            "PDX_ribo_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-Ribodeplete_for_GEO_20240520.tsv"
+        }
+
+        self.clinical_targets = {
+            "tumor_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_TumorCompendium_v11_PolyA_for_GEO_20240520.tsv",
+            "tumor_ribo_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/Treehouse-PDX-Compendium-22.03-PolyA_hugo_log2tpm_58581genes_2022-03-09.tsv",
+            "cell_line_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_CellLinePolyA_21.06_for_GEO_20240520.tsv",
+            "PDX_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
+            "PDX_ribo_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-Ribodeplete_for_GEO_20240520.tsv"
+        }

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -117,13 +117,13 @@ class ProductionConfig(ScriptConfig):
         "tumor_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/TumorCompendium_v11_PolyA_hugo_log2tpm_58581genes_2020-04-09.tsv",
         "tumor_ribo_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/TreehousePEDv9_Ribodeplete_unique_hugo_log2_tpm_plus_1.2019-03-25.tsv",
         "cell_line_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/CellLinePolyA_21.06_hugo_log2tpm_58581genes_2021-06-15.tsv",
-        "PDX_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
-        "PDX_ribo_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-Ribodeplete_for_GEO_20240520.tsv"
+        "PDX_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu:443/download/Treehouse-PDX-Compendium-22.03-PolyA_hugo_log2tpm_58581genes_2022-03-09.tsv",
+        "PDX_ribo_expression.tsv": "https://xena.treehouse.gi.ucsc.edu:443/download/Treehouse-PDX-Compendium-22.03-Ribodeplete_hugo_log2tpm_58581genes_2022-03-10.tsv"
     }
 
     clinical_targets = {
         "tumor_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_TumorCompendium_v11_PolyA_for_GEO_20240520.tsv",
-        "tumor_ribo_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/Treehouse-PDX-Compendium-22.03-PolyA_hugo_log2tpm_58581genes_2022-03-09.tsv",
+        "tumor_ribo_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu:443/download/TreehousePEDv9_Ribodeplete_clinical_metadata_for_GEO_20240520.tsv",
         "cell_line_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_CellLinePolyA_21.06_for_GEO_20240520.tsv",
         "PDX_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
         "PDX_ribo_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-Ribodeplete_for_GEO_20240520.tsv"
@@ -137,7 +137,7 @@ class PDXPolyA(ScriptConfig):
 
     data_dir = os.path.join('data', 'pdx_polya')
     expression_targets = {
-        "polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
+        "PDX_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu:443/download/Treehouse-PDX-Compendium-22.03-PolyA_hugo_log2tpm_58581genes_2022-03-09.tsv",
     }
 
     clinical_targets = {

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -133,11 +133,11 @@ class PDXPolyA(ScriptConfig):
 
     data_dir = os.path.join('data', 'pdx_polya')
     expression_targets = {
-        "TEST_PDX_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
+        "polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
     }
 
     clinical_targets = {
-        "TEST_PDX_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
+        "PDX_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
     }
 
 VALID_CONFIGS = ["production", "pdx_polya"]

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -22,7 +22,8 @@ class ScriptConfig:
             Example: {"file_clinical.tsv": "https://example.com/file_clinical.tsv"}
     """
 
-    project_root = '.'
+    # Get the current file and move up one directory to the project directory
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
     data_dir = 'data'
     raw_data_dir = 'raw'
     processed_dir = 'processed'
@@ -132,11 +133,11 @@ class PDXPolyA(ScriptConfig):
 
     data_dir = os.path.join('data', 'pdx_polya')
     expression_targets = {
-        "PDX_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
+        "TEST_PDX_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
     }
 
     clinical_targets = {
-        "PDX_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
+        "TEST_PDX_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
     }
 
 VALID_CONFIGS = ["production", "pdx_polya"]

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -137,3 +137,29 @@ class CLPolyA(ScriptConfig):
     clinical_targets = {
         "cell_line_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_CellLinePolyA_21.06_for_GEO_20240520.tsv",
     }
+
+# Define a constant list of valid configurations
+VALID_CONFIGS = ["production", "clpolya"]
+
+def get_config(config_name):
+    """
+    Returns the appropriate configuration class based on the provided command line argument.
+
+    Args:
+        config_name (str): The name of the configuration to use. Available options are:
+            - "production": Use the ProductionConfig class.
+            - "clpolya": Use the CLPolyA class.
+
+    Returns:
+        ScriptConfig: The configuration class corresponding to the provided name, or None if an invalid configuration name is provided.
+
+    Prints:
+        str: An error message if an invalid configuration name is provided.
+    """
+    if config_name == "production":
+        return ProductionConfig
+    elif config_name == "clpolya":
+        return CLPolyA
+    else:
+        print(f"Invalid configuration name: {config_name}. Valid configurations are: {', '.join(VALID_CONFIGS)}")
+        return None

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -1,29 +1,28 @@
 import os
 import requests
+import argparse
+from config import get_config, VALID_CONFIGS
 from paths import RAW_DATA_DIR
 
 """
 Script to download genomic data and outputs both clinical and expression data files as TSV.
 """
 
-def ensure_dirs():
-    """Ensure the download directory exists."""
-    os.makedirs(RAW_DATA_DIR, exist_ok=True)
-
-def download_file(url: str, filename: str):
+def download_file(url: str, file_path: str):
     """
-    Downloads a file from the given URL and saves it in the RAW_DATA_DIR directory.
+    Downloads a file from the given URL and saves it in the specified file path.
 
     Parameters:
     url (str): The file URL.
-    filename (str): The filename to save as.
+    file_path (str): The full file path to save the file.
     """
-    file_path = os.path.join(RAW_DATA_DIR, filename)
-
     try:
         # Bypass SSL verification
         response = requests.get(url, stream=True, verify=False)
         response.raise_for_status()
+
+        # Ensure the directory exists
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
         with open(file_path, "wb") as file:
             for chunk in response.iter_content(chunk_size=8192):
@@ -32,44 +31,44 @@ def download_file(url: str, filename: str):
         print(f"Downloaded: {file_path}")
 
     except requests.exceptions.RequestException as e:
-        print(f"Failed to download {filename}: {e}")
+        print(f"Failed to download {file_path}: {e}")
 
 def download_files(file_dict):
     """
-    Downloads multiple files from a dictionary of URLs and filenames.
+    Downloads multiple files from a dictionary. The keys are file paths and the values are URLs.
 
-    Parameters:
-    file_dict (dict): Dictionary where keys are filenames and values are URLs.
+    Args:
+        file_dict (dict): Dictionary where keys are file paths and values are URLs.
     """
-    for filename, url in file_dict.items():
+
+    for file_path, url in file_dict.items():
+        filename = os.path.basename(file_path)
         print(f"Downloading {filename} from {url}...")
-        download_file(url, filename)
+        download_file(url, file_path)
 
 if __name__ == "__main__":
-    ensure_dirs()
+    parser = argparse.ArgumentParser(description="Download genomic data files.")
+    # Create an argument for the configuration name
+    parser.add_argument(
+        "--config",
+        type=str,
+        required=True,
+        help=f"Configuration name (e.g., {', '.join(VALID_CONFIGS)})"
+    )
+    args = parser.parse_args()
 
-    # Dictionary of files to download
-    files_to_download = {
-        # Tumor Compendium (PolyA)
-        "tumor_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/TumorCompendium_v11_PolyA_hugo_log2tpm_58581genes_2020-04-09.tsv",
-        "tumor_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_TumorCompendium_v11_PolyA_for_GEO_20240520.tsv",
+    # Get the configuration class based on the configuration name
+    config = get_config(args.config)
+    if config is None:
+        # If the configuration is not found, indicate which configurations are available and exit.
+        print(f"Configuration not found. Available configurations are:{VALID_CONFIGS}")
+        exit(1)
 
-        # Tumor Compendium (Ribo)
-        "tumor_ribo_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/TreehousePEDv9_Ribodeplete_unique_hugo_log2_tpm_plus_1.2019-03-25.tsv",
-        "tumor_ribo_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/Treehouse-PDX-Compendium-22.03-PolyA_hugo_log2tpm_58581genes_2022-03-09.tsv",
+    # Create the raw data directory if it does not exist
+    os.makedirs(config.raw_data_dir_path(), exist_ok=True)
 
-        # Cell Line Compendium (PolyA)
-        "cell_line_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/CellLinePolyA_21.06_hugo_log2tpm_58581genes_2021-06-15.tsv",
-        "cell_line_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_CellLinePolyA_21.06_for_GEO_20240520.tsv",
+    # Merge expression and clinical file paths and url targets into a single dictionary
+    files_to_download = {**config.get_path_expression_url_targets(), **config.get_path_clinical_url_targets()}
 
-        # PDX Compendium (PolyA)
-        "PDX_polyA_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
-        "PDX_polyA_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-PolyA_for_GEO_20240520.tsv",
-
-        # PDX Compendium (Ribo)
-        "PDX_ribo_expression.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-Ribodeplete_for_GEO_20240520.tsv",
-        "PDX_ribo_clinical.tsv": "https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-PDX-Compendium-22.03-Ribodeplete_for_GEO_20240520.tsv",
-    }
-
-    print(f"Files will be saved in: {RAW_DATA_DIR}\n")
+    print(f"Files will be saved in: {config.raw_data_dir_path()}\n")
     download_files(files_to_download)


### PR DESCRIPTION
Add configuration objects for project scripts.

**Purpose**: 
The full 5 data sets are large and cumbersome to use in development and testing. It is desirable to be able to select a smaller data set or a specific test set in order for more efficient development and testing of scripts. 

Script configuration allow for us to define specific sets of data that we want to run our scripts with. Script configurations define where all of the save directories are, what all of the data file paths are, and what the associated urls for data downloads are. Script configurations can include as many or as few data files as they want. For example, the production configuration would include the 5 data sets from the design doc, but maybe a good test configuration would only pick one smallest expression and compendium data pairing to work with. The ScriptConfig class defines an interface for how a script can access all of the io and url information from a configuration object.

Scripts are told what configuration to use with a command line argument. They need to implement argparse and create a argument called --config that takes a string configuration name. config.py has a const VALID_CONFIGS that defines valid configuration names. Then config.get_config(config_name) will return the configuration class corresponding to the configuration name string. The class returned will be derived from ScriptConfig, and will support all of the interface methods for accessing directory and file name information. The script can then generically operate and reference the ScriptConfig object when it needs to read/write/fetch data. See download_data.py for an example implementation.

When scripts are run sequentially, it is intended that they use the same configuration. It is not enforced, so scripts need to make sure data exists before they try and preform operations on them. For example configuration A could be used to for the download script and configuration B could be used for the preprocess script and the preprocessing script may end up looking for files that don't exist because config A and B define different files.