### PR TITLE
Feature/pre process missing genes

### DIFF
--- a/tests/preprocessing_test.py
+++ b/tests/preprocessing_test.py
@@ -91,7 +91,6 @@ def verify_processed_compendium(processed_compendium):
     """
     patients = ["Patient_A", "Patient_B", "Patient_C", "Patient_D", "Patient_E", "Patient_F"]
     assert all(patient in processed_compendium.index for patient in patients)
-    assert "compendium" in processed_compendium.columns
 
 def test_format_process_expression_compendium(expression_dict):
     """
@@ -102,9 +101,9 @@ def test_format_process_expression_compendium(expression_dict):
     # Call the function to test
     processed_compendium = process_expression_compendium(expression_dict)
 
-    # The processed compendium should have one column "compendium" and 10 gene columns. Index column doesn't get counted.
+    # The processed compendium should have 10 gene columns. Index column doesn't get counted.
     # 6 samples so should have 6 rows
-    assert processed_compendium.shape == (6, 11)
+    assert processed_compendium.shape == (6, 10)
 
     # Check that the indexes are the same as the patient IDs
     verify_processed_compendium(processed_compendium)

--- a/tests/preprocessing_test.py
+++ b/tests/preprocessing_test.py
@@ -44,6 +44,36 @@ def expression_dict():
     return expression_dict
 
 @pytest.fixture
+def expression_dict_mismatched_genes():
+    """
+    Create a dictionary of expression dataframes for testing purposes. data1 and data2 represent two different compendia.
+    Both compendia have entries for 'gene_1' but only data1 has entries for 'gene_3', and only data2 has entries for
+    'gene_2'.
+    """
+
+    patients1 = ["Patient_A", "Patient_B", "Patient_C"]
+    patients2 = ["Patient_D", "Patient_E", "Patient_F"]
+
+    data1 = {
+        "gene_1": [5.2, 4.8, 5.0],
+        "gene_3": [7.5, 6.7, 7.0],
+    }
+
+    data2 = {
+        "gene_1": [5.1, 4.9, 5.0],
+        "gene_2": [3.2, 2.8, 3.1],
+    }
+
+    df1 = pd.DataFrame(data1, index=patients1)
+    df2 = pd.DataFrame(data2, index=patients2)
+
+    expression_dict = {
+        "compendium1": df1,
+        "compendium2": df2
+    }
+    return expression_dict
+
+@pytest.fixture
 def clinical_dict():
     """
     Create a dictionary of clinical dataframes for testing purposes. data1 and data2 represent two different compendia.
@@ -152,6 +182,33 @@ def test_min_var_process_expression_compendium(expression_dict):
         # Make sure that the other genes are still present
         for gene in gene_variances.nlargest(10 - i).index:
             assert gene in processed_compendium.columns
+
+def test_process_expression_compendium_mismatched_genes(expression_dict_mismatched_genes):
+    """
+    Test the process_expression_compendium function with a dictionary of expression dataframes that have
+    mismatched genes. Ensure that the processed compendium has all genes from the dictionary and that missing values
+    were filled with 0s.
+    """
+
+    processed_compendium = process_expression_compendium(expression_dict_mismatched_genes)
+
+    # Ensure all genes from the dictionary are present in the processed compendium
+    all_genes = set()
+    for df in expression_dict_mismatched_genes.values():
+        all_genes.update(df.columns)
+    assert all(gene in processed_compendium.columns for gene in all_genes)
+
+    # Ensure there are no NaN values in the processed compendium
+    assert not processed_compendium.isnull().values.any()
+
+    # Ensure that missing values were filled with 0s
+    for gene in all_genes:
+        for df in expression_dict_mismatched_genes.values():
+            if gene not in df.columns:
+                assert (processed_compendium.loc[df.index, gene] == 0).all()
+
+    # Ensure that the indexes are the same as the patient IDs
+    verify_processed_compendium(processed_compendium)
 
 def test_process_clinical_compendium(clinical_dict):
     """


### PR DESCRIPTION
**Purpose:**
Prevent layout algorithms from having to deal with NaN values in expression compendium data frames.

When building a compendium from samples, not all samples have expression data for the same genes. Nevertheless, all genes need to have columns in the final compendium. By default concatenating data frames fills these columns with NaN if a sample does not have data for a specific gene. This causes issues when applying layout algorithms because each sample can have various NaN values across genes.

This code ensures that instead of NaN values, values of 0 are inserted into gene values for samples that don't have pre-existing data for the gene.

In addition, this code also removes the compendium label from the expression data frame. This allows the data frame to be fully numeric and prevents any layout algorithms from having to handle non-numeric columns. The compendium of origin is still available through a cross lookup of the sample id in the clinical compendium. 