### PR TITLE
feature/umap

### DIFF
--- a/scripts/generate_layouts.py
+++ b/scripts/generate_layouts.py
@@ -1,52 +1,38 @@
-import sys
-import os
-from matplotlib import pyplot as plt
 import pandas as pd
-import umap
+import argparse
+import matplotlib.pyplot as plt
 from layout_algorithms.mcm_umap import MCMUmap
-from paths import EXPRESSION_FILE, CLINICAL_FILE
+from config import ScriptConfig, get_config, VALID_CONFIGS
 
-'''
-Label data points based on compendium of origin for
-adding labels to data points for each compendium in the map
-'''
-
-# Load expression data into DataFrame
-df_expr = pd.read_csv(EXPRESSION_FILE, sep="\t", index_col=0, low_memory=False)
-print(f"Expression data shape: {df_expr.shape}")
-
-# Load clinical data into DataFrame
-df_clinical = pd.read_csv(CLINICAL_FILE, sep="\t", index_col=0, low_memory=False)
-print(f"Clinical data shape: {df_clinical.shape}")
-
-compressed_df = MCMUmap().fit_transform(df_expr)
-
-# UMAP Utility Function for testing
-# TODO: Write more tests with different neighbors and distance values
-def draw_umap(data, n_neighbors=15, min_dist=0.1, n_components=2, metric='euclidean', title=''):
-    fit = umap.UMAP(
-        n_neighbors=n_neighbors,
-        min_dist=min_dist,
-        n_components=n_components,
-        metric=metric
+if __name__ == '__main__':
+    # Command line argument parsser to get configuration
+    parser = argparse.ArgumentParser(description="Process genomic data files.")
+    parser.add_argument(
+        "--config",
+        type=str,
+        required=True,
+        help=f"Configuration name (e.g., {', '.join(VALID_CONFIGS)})"
     )
-    u = fit.fit_transform(data)
-    fig = plt.figure()
-    if n_components == 1:
-        ax = fig.add_subplot(111)
-        ax.scatter(u[:,0], range(len(u)), c=data)
-    if n_components == 2:
-        ax = fig.add_subplot(111)
-        ax.scatter(u[:,0], u[:,1], c=data)
-    if n_components == 3:
-        ax = fig.add_subplot(111, projection='3d')
-        ax.scatter(u[:,0], u[:,1], u[:,2], c=data, s=100)
-    plt.title(title, fontsize=18)
+    args = parser.parse_args()
+
+    # Get configuration
+    config = get_config(args.config)
+
+    # Load expression data
+    expression_df = pd.read_csv(config.expression_file_path(), sep="\t", index_col=0)
+
+    layout_algorithm = MCMUmap()
+
+    # Perform layout algorithm
+    layout_df = layout_algorithm.fit_transform(expression_df)
+
+    # Assuming layout_df has columns 'UMAP1' and 'UMAP2'
+    plt.figure(figsize=(10, 6))
+    plt.scatter(layout_df['UMAP1'], layout_df['UMAP2'], s=10, alpha=0.7)
+    plt.title('UMAP Layout')
+    plt.xlabel('UMAP1')
+    plt.ylabel('UMAP2')
+    plt.grid(True)
     plt.show()
 
-# UMAP visualization tests - replace numbers above with these numbers
-# n_neighbors values: 5, 15, 30
-# min_dist values: 0.1, 0.25, 0.5  
-# n_components values: 1, 2, 3
-# metric values: 'euclidean', 'correlation' --> most likely will use euclidean
-# but it would be cool to see what correlation looks like, maybe it fits our data better or not?
+    pass

--- a/scripts/generate_layouts.py
+++ b/scripts/generate_layouts.py
@@ -19,7 +19,7 @@ print(f"Expression data shape: {df_expr.shape}")
 df_clinical = pd.read_csv(CLINICAL_FILE, sep="\t", index_col=0, low_memory=False)
 print(f"Clinical data shape: {df_clinical.shape}")
 
-compressed_df = MCMUmap().fit_transform(df_expr, df_clinical)
+compressed_df = MCMUmap().fit_transform(df_expr)
 
 # UMAP Utility Function for testing
 # TODO: Write more tests with different neighbors and distance values

--- a/src/layout_algorithms/base_layout.py
+++ b/src/layout_algorithms/base_layout.py
@@ -3,19 +3,22 @@ import pandas as pd
 
 class BaseLayout(ABC):
     """
-    API for threshold algorithms.
+    API for threshold algorithms. To make a new layout algorithm, inherit from this class and implement the fit_transform
+    method.
     """
 
     @abstractmethod
-    def fit_transform(self, expression_df: pd.DataFrame, clinical_df: pd.DataFrame) -> pd.DataFrame:
+    def fit_transform(self, expression_df: pd.DataFrame) -> pd.DataFrame:
         """
-        Perform the layout algorithm on the given data.
+        Perform a layout algorithm on the given dataframe. Examples TSNE, PCA, UMAP. The input should be high
+        dimensional gene expression data and the output should be a 2D representation of the data.
 
         Parameters:
-        expression_df (pd.DataFrame): The gene expression data.
-        clinical_df (pd.DataFrame): The clinical data.
+        expression_df (pd.DataFrame): The gene expression data. All columns should be genes and all rows should be
+            samples. The index should be the sample ids. There should be no missing values ie no NaNs. All samples
+            should have the same genes.
 
         Returns:
-        pd.DataFrame: The transformed data with layout coordinates.
+        pd.DataFrame: This dataframe should have dimension 2. The index should be the sample ids.
         """
         pass

--- a/src/layout_algorithms/mcm_umap.py
+++ b/src/layout_algorithms/mcm_umap.py
@@ -11,7 +11,7 @@ from preprocessing import process_expression_compendium, process_clinical_compen
 
 class MCMUmap(BaseLayout):
 
-    def fit_transform(self, expression_df, clinical_df):
+    def fit_transform(self, expression_df):
         '''
         UMAP setup
 
@@ -25,7 +25,7 @@ class MCMUmap(BaseLayout):
         reducer = umap.UMAP()
 
         # Ensure correct data merging
-        merged_data = pd.merge(expression_df, clinical_df, left_index=True, right_index=True)
+        merged_data = pd.merge(expression_df, left_index=True, right_index=True)
 
         # Drop missing values if needed
         merged_data = merged_data.dropna()

--- a/src/layout_algorithms/mcm_umap.py
+++ b/src/layout_algorithms/mcm_umap.py
@@ -1,47 +1,34 @@
-from abc import ABC
-
 from sklearn.preprocessing import StandardScaler
-import matplotlib.pyplot as plt
-import seaborn as sns
 import pandas as pd
 import umap
 from .base_layout import BaseLayout
-from IPython import get_ipython
-from preprocessing import process_expression_compendium, process_clinical_compendium
 
 class MCMUmap(BaseLayout):
 
     def fit_transform(self, expression_df):
-        '''
-        UMAP setup
+        """
+        Perform UMAP layout algorithm on the given dataframe. This implementation uses the UMAP algorithm from the
+        umap-learn library.
 
-        This is the skeleton for UMAP integration.
-        '''
-        
-        # Map seaborn for plotting
-        sns.set_theme(style="white", context='poster', rc={'figure.figsize': (14, 10)})
+        Args:
+            expression_df (pd.DataFrame): The gene expression data. All columns should be genes and all rows should be
+                samples. The index should be the sample ids. There should be no missing values ie no NaNs. All samples
+                should have the same genes.
 
-        # Use umap library and initiate class
-        reducer = umap.UMAP()
-
-        # Ensure correct data merging
-        merged_data = pd.merge(expression_df, left_index=True, right_index=True)
-
-        # Drop missing values if needed
-        merged_data = merged_data.dropna()
+        Returns:
+            pd.DataFrame: This dataframe should have dimension 2. The index should be the sample ids.
+        """
 
         # Standardize expression data
         scaler = StandardScaler()
-        expression_scaled = scaler.fit_transform(merged_data)
+        expression_scaled = scaler.fit_transform(expression_df)
 
         # Perform UMAP dimensionality reduction
         reducer = umap.UMAP(n_components=2, n_neighbors=15, min_dist=0.1, metric="correlation", random_state=42)
         embedding = reducer.fit_transform(expression_scaled)
 
-        # TODO: modify n_neighbors and min_dist to see how it affects the map
-        # and how it affects the clustering of samples
+        # Convert the embedding to a DataFrame
+        embedding_df = pd.DataFrame(embedding, index=expression_df.index, columns=['UMAP1', 'UMAP2'])
 
-        # Possible test:
-        # reducer = umap.UMAP(n_components=2, n_neighbors=30, min_dist=0.2, metric="correlation", random_state=42)
-        # embedding = reducer.fit_transform(expression_scaled)
+        return embedding_df
 


### PR DESCRIPTION
Baseline code required to get simple umap plot generated.

**BaseLayout api changes:**
fit_transform definition only expects the expression data frame. This means that to make a layout algorithm, the steps are:

1) Subclass BaseLayout
2) Implement fit_transform(expression_df)

Previously, the clinical data frame was also included in fit_transform params. The layout algorithm should be some type of mathematical function that is executed on numerical gene expression data only, not clinical data. The only purpose of the clinical data frame is for plotting which should not happen in the same place as layout algorithms.

**generate_layouts script changes:**
- Create argparser for cl argument to specify a script configuration. See pr #1.
- Remove doing umap algorithm in this script. It already is implemented in the layout_algorithms.mcm_umap module. Simply make a call to that module and execute fit_transform on the MCMUmap BaseLayout subclass.
- Generate example plot. This is very temporary and will need to be elaborated on.
